### PR TITLE
Update README with API URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ create a .env file with the following:
 NEXTAUTH_SECRET
 SPOTIFY_CLIENT_ID
 SPOTIFY_CLIENT_SECRET
+NEXT_PUBLIC_API_URL - API base URL
 
 ```bash
 npm run dev


### PR DESCRIPTION
## Summary
- document `NEXT_PUBLIC_API_URL` in setup instructions

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863b968c4e8832c986f114a0d2dc41b