### PR TITLE
Fix playlist fetch with useEffect

### DIFF
--- a/src/app/playlists/page.tsx
+++ b/src/app/playlists/page.tsx
@@ -33,7 +33,11 @@ export default function Playlists() {
   const [playlistDetails, setPlaylistDetails] = useState<PlaylistDetails>();
   const [error, setError] = useState<ErrorResponse>();
 
-  if (session && !playlistArray && !error) {
+  useEffect(() => {
+    if (!session || playlistArray || error) {
+      return;
+    }
+
     fetch("/api/spotify/playlists")
       .then((res) => {
         if (!res.ok) {
@@ -46,10 +50,10 @@ export default function Playlists() {
           setError(data.error);
           return;
         }
-        console.log(data)
+        console.log(data);
         setPlaylistArray(data);
       });
-  }
+  }, [session]);
 
   useEffect(() => { 
     if (!playlistId) {


### PR DESCRIPTION
## Summary
- wrap playlist fetch logic in a `useEffect`
- only trigger once session is available and a playlist hasn't been loaded

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863b979d71c832ca0e448c5260bad52