### PR TITLE
Add Jest test for spotify playlist endpoint

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,11 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+const customJestConfig = {
+  testEnvironment: 'node',
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "export AWS_PROFILE=\"george\" && next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@aws-amplify/backend": "^1.8.0",
@@ -18,14 +19,18 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.14",
     "@types/next-auth": "^3.13.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8",
     "eslint-config-next": "^15.0.3",
+    "jest": "^29.7.0",
+    "next-test-api-route-handler": "^4.0.16",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
+    "ts-jest": "^29.4.0",
     "typescript": "^5"
   }
 }

--- a/tests/api/spotify/playlist.test.ts
+++ b/tests/api/spotify/playlist.test.ts
@@ -1,0 +1,21 @@
+import { testApiHandler } from 'next-test-api-route-handler';
+import { GET } from '../../../src/app/api/spotify/playlist/route';
+import { getToken } from 'next-auth/jwt';
+
+jest.mock('next-auth/jwt');
+
+const mockedGetToken = getToken as jest.MockedFunction<typeof getToken>;
+
+describe('GET /api/spotify/playlist', () => {
+  it('returns 401 when no valid token', async () => {
+    mockedGetToken.mockResolvedValue(null as any);
+    await testApiHandler({
+      appHandler: { GET },
+      url: 'http://example.com/api/spotify/playlist',
+      test: async ({ fetch }) => {
+        const res = await fetch({ method: 'GET' });
+        expect(res.status).toBe(401);
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest config using `next/jest`
- add dev dependencies for running tests
- test that playlist API route returns 401 without a token

## Testing
- `npx jest tests/api/spotify/playlist.test.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6863b96c8c74832caf7d8327ec1b38b6