### PR TITLE
Fix token expiry calculation in auth handler

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -44,7 +44,10 @@ const options: NextAuthOptions = {
                 return {
                     ...token,
                     access_token: data.access_token,
-                    accessTokenExpires: Date.now() + data.expires_in
+                    // Spotify returns expires_in in seconds. Convert to an
+                    // absolute expiry time in seconds to match the initial
+                    // `account.expires_at` value.
+                    accessTokenExpires: Math.floor(Date.now() / 1000 + data.expires_in)
                 }
             }catch(e){
                 console.log(e);


### PR DESCRIPTION
## Summary
- ensure refreshed Spotify tokens store expiry time in seconds to match initial login

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863b81b9dac832ca39d67324f5333e8