### PR TITLE
Implement single playlist selection

### DIFF
--- a/src/app/api/spotify/playlists/route.ts
+++ b/src/app/api/spotify/playlists/route.ts
@@ -98,3 +98,44 @@ export async function POST(req: NextRequest) {
     );
   }
 }
+
+export async function DELETE(req: NextRequest) {
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  if (!token || !token.access_token || !token.sub) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { playlistId }: { playlistId: string } = await req.json();
+
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}api/user`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        userId: token.name,
+        playlistId,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error("Network response was not ok");
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error(
+      "Error calling API:",
+      error instanceof Error ? error.message : String(error)
+    );
+    return NextResponse.json(
+      {
+        message: "Error calling API",
+        error: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/playlists/page.tsx
+++ b/src/app/playlists/page.tsx
@@ -77,34 +77,50 @@ export default function Playlists() {
 
   const onPlaylistClick = async (item: string) => {
     try {
+      const existing = playlistArray?.items.find((p) => p?.isExisting);
+      if (existing && existing.id !== item) {
+        const delRes = await fetch('/api/spotify/playlists', {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ playlistId: existing.id }),
+        });
+
+        if (!delRes.ok) {
+          throw new Error('Delete request failed');
+        }
+      }
+
       const response = await fetch('/api/spotify/playlists', {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "Content-Type": "application/json",
+          'Content-Type': 'application/json',
         },
         body: JSON.stringify({ playlistId: item }),
       });
-      
+
       if (!response.ok) {
-        throw new Error("Network response was not ok");
+        throw new Error('Network response was not ok');
       }
+
       // todo have the post return so don’t need to double call from front end
-      fetch("/api/spotify/playlists")
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error("Failed to fetch");
-        }
-        return res.json();
-      })
-      .then((data) => {
-        if (data.error) {
-          setError(data.error);
-          return;
-        }
-        setPlaylistArray(data);
-      });
+      fetch('/api/spotify/playlists')
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error('Failed to fetch');
+          }
+          return res.json();
+        })
+        .then((data) => {
+          if (data.error) {
+            setError(data.error);
+            return;
+          }
+          setPlaylistArray(data);
+        });
     } catch (error) {
-      console.error("Error calling API:", error);
+      console.error('Error calling API:', error);
     }
     setPlaylistId(item);
   };


### PR DESCRIPTION
## Summary
- restrict playlist selection to one
- call delete endpoint before posting a new playlist
- expose DELETE handler for playlists API route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a5be3d458832c9bfcfcb2fd7a6efe