### PR TITLE
Add user playlist API with DELETE method

### DIFF
--- a/src/app/api/user/[userId]/route.ts
+++ b/src/app/api/user/[userId]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var userPlaylists: Map<string, Set<string>> | undefined;
+}
+
+const userPlaylists: Map<string, Set<string>> = globalThis.userPlaylists || new Map();
+if (!globalThis.userPlaylists) {
+  globalThis.userPlaylists = userPlaylists;
+}
+
+export async function GET(req: NextRequest, { params }: { params: { userId: string } }) {
+  const { userId } = params;
+  if (!userId) {
+    return NextResponse.json({ message: "userId required" }, { status: 400 });
+  }
+  const playlists = Array.from(userPlaylists.get(userId) || []);
+  return NextResponse.json(playlists);
+}

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var userPlaylists: Map<string, Set<string>> | undefined;
+}
+
+// In-memory store for playlists per user
+const userPlaylists: Map<string, Set<string>> = globalThis.userPlaylists || new Map();
+if (!globalThis.userPlaylists) {
+  globalThis.userPlaylists = userPlaylists;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { userId, playlistId } = await req.json();
+    if (!userId || !playlistId) {
+      return NextResponse.json({ message: "userId and playlistId required" }, { status: 400 });
+    }
+    const playlists = userPlaylists.get(userId) || new Set<string>();
+    playlists.add(playlistId);
+    userPlaylists.set(userId, playlists);
+    return NextResponse.json({ message: "Playlist added" });
+  } catch (error) {
+    return NextResponse.json({ message: "Invalid request" }, { status: 400 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const { userId, playlistId } = await req.json();
+    if (!userId || !playlistId) {
+      return NextResponse.json({ message: "userId and playlistId required" }, { status: 400 });
+    }
+    const playlists = userPlaylists.get(userId);
+    if (playlists) {
+      playlists.delete(playlistId);
+    }
+    return NextResponse.json({ message: "Playlist deleted" });
+  } catch (error) {
+    return NextResponse.json({ message: "Invalid request" }, { status: 400 });
+  }
+}


### PR DESCRIPTION
## Summary
- implement in-memory API route for user playlists
- support GET, POST, DELETE

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a7098c998832c80fab37e5a3bd80c